### PR TITLE
Add tokenization exception reporting to KFST and exception handling to pyvoikko

### DIFF
--- a/kfst/kfst/__init__.py
+++ b/kfst/kfst/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with KFST. If not, see <https://www.gnu.org/licenses/>.
 
-from .transducer import FST
+from .transducer import FST, TokenizationException

--- a/kfst/kfst/transducer.py
+++ b/kfst/kfst/transducer.py
@@ -224,7 +224,7 @@ class FST(NamedTuple):
         """
 
         input_symbols = self.split_to_symbols(input)
-        if input_symbols == None:
+        if input_symbols is None:
             raise TokenizationException("Input cannot be split into symbols")
 
         results = self.run_fst(input_symbols, state=state)

--- a/kfst/kfst/transducer.py
+++ b/kfst/kfst/transducer.py
@@ -23,6 +23,9 @@ from typing import Mapping, NamedTuple
 
 from frozendict import frozendict
 
+class TokenizationException(Exception):
+    """Raised when failing to convert input string to symbols in KFST."""
+    pass
 
 class FSTState(NamedTuple):
     state_num: int
@@ -216,10 +219,14 @@ class FST(NamedTuple):
         Yields a tuple of (output_symbols, path_weight) for each successful path.
         
         Otherwise same as run_fst, but operates on strings instead of symbol lists, filters out duplicate outputs and sorts the results by weight.
+
+        Raises a TokenizationException if the input string can not be converted into the symbols of the KFST transducer.
         """
 
         input_symbols = self.split_to_symbols(input)
-        assert input_symbols is not None, "Input cannot be split into symbols"
+        if input_symbols == None:
+            raise TokenizationException("Input cannot be split into symbols")
+
         results = self.run_fst(input_symbols, state=state)
         results = sorted(results, key=lambda x: x[1])
         already_seen = set()

--- a/pyvoikko/pyvoikko/__init__.py
+++ b/pyvoikko/pyvoikko/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os.path
 
-from kfst import FST
+from kfst import FST, TokenizationException
 
 from .analysis import VoikkoAnalysis
 
@@ -21,7 +21,10 @@ def analyse(word: str) -> list[VoikkoAnalysis]:
         list of `VoikkoAnalysis` objects
     """
     ans = []
-    for analysis, _weight in VOIKKO_FST.lookup(word):
-        ans.append(VoikkoAnalysis.from_voikko_analysis(analysis))
+    try:
+        for analysis, _weight in VOIKKO_FST.lookup(word):
+            ans.append(VoikkoAnalysis.from_voikko_analysis(analysis))
+    except TokenizationException:
+        pass
     
     return ans


### PR DESCRIPTION
Pyvoikko lets an exception bubble through in this case:

`pyvoikko.analyse("sana_liitto")`

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<snip>/venv/lib/python3.11/site-packages/pyvoikko/__init__.py", line 24, in analyse
    for analysis, _weight in VOIKKO_FST.lookup(word):
  File "<snip>/venv/lib/python3.11/site-packages/kfst/transducer.py", line 286, in lookup
    assert input_symbols is not None, "Input cannot be split into symbols"
           ^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: Input cannot be split into symbols
```

libvoikko simply returns `[]`

This PR makes KFST produce a more descriptive exception instead of an assertion error and makes pyvoikko return [] in line with libvoikko.